### PR TITLE
Fix/not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It may be easier to think of this extension as if they were 3 components:
  - the part that communicates with the Codeship api
  - the part that interacts with the Bitbucket pages
 
- The extension was built using [yeoman](http://yeoman.io) and the [chrome extension kickstarter generator](https://github.com/yeoman/generator-chrome-extension).  
+ The extension was built using [yeoman](http://yeoman.io) and the [chrome extension kickstarter generator](https://github.com/HaNdTriX/generator-chrome-extension-kickstart) (thanks @HaNdTriX for it!).  
  Having a [Codeship Api Key](https://codeship.com/documentation/integrations/api/#get-a-api-key) makes it easy to do simple queries to collect data about Codeship projects and builds.  
  The extension itself runs (although it seems to be active all the time) only on Bitbucket pull request pages and asks Codeship for the user's project list. If the Bitbucket project that the extension runs on is in the project list, then (after *scraping* :( the pull request branch) BitShip gets the Codeship build status for the pull request.
  The next step is some kind of css voodoo magic that adds a class to the root node of the page. Based on that class, the pull request page UI is modified so it reveals the Codeship badge with a status message:  

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -32,8 +32,8 @@
   "content_scripts": [
     {
       "matches": [
-        "http://bitbucket.org/*pull-request/*",
-        "https://bitbucket.org/*pull-request/*"
+        "http://bitbucket.org/*pull-requests/*/*",
+        "https://bitbucket.org/*pull-requests/*/*"
       ],
       "css": [
         "styles/content.css"

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appShortName__",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",
   "icons": {


### PR DESCRIPTION
Updated the bitbucket pull-request url pattern

Since bitbucket updated the single pull request page from 
- bitbucket.org/organization/repo/**pull-request**/id/name  

to  
- bitbucket.org/organization/repo/**pull-requests**/id/name

The extension wasn't working anymore, as stated in #16.
